### PR TITLE
Fix memory leaks

### DIFF
--- a/cpp1.c
+++ b/cpp1.c
@@ -42,6 +42,7 @@ int PREFIX fppPreProcess(REG(a0) struct fppTag *tags)
 {
   int i=0;
   ReturnCode ret;       /* cpp return code */
+  int retVal;           /* fppPreProcess return code */
   struct Global *global;
 
   global=(struct Global *)malloc(sizeof(struct Global));
@@ -143,10 +144,16 @@ int PREFIX fppPreProcess(REG(a0) struct fppTag *tags)
   }
   fflush(stdout);
   fclose(stdout);
+  delalldefines(global);
 
+  retVal = IO_NORMAL;
   if (global->errors > 0 && !global->eflag)
-    return(IO_ERROR);
-  return(IO_NORMAL);       /* No errors or -E option set   */
+    retVal = IO_ERROR;
+  free(global->tokenbuf);
+  free(global->functionname);
+  free(global->spacebuf);
+  free(global);
+  return retVal;       /* No errors or -E option set   */
 }
 
 INLINE FILE_LOCAL

--- a/cpp3.c
+++ b/cpp3.c
@@ -356,7 +356,7 @@ ReturnCode initdefines(struct Global *global)
   return(FPP_OK);
 }
 
-void deldefines(struct Global *global)
+void delbuiltindefines(struct Global *global)
 {
   /*
    * Delete the built-in #define's.

--- a/cpp6.c
+++ b/cpp6.c
@@ -618,12 +618,35 @@ DEFBUF *defendel(struct Global *global,
 }
 
 
+void delalldefines(struct Global *global)
+{
+  /*
+   * Delete all the defines in the tables and free memory
+   */
+
+  DEFBUF *dp;
+  DEFBUF *prevp;
+  int i;
+
+  for (i = 0; i < SBSIZE; ++i)
+  {
+    prevp = global->symtab[i];
+    while ((dp = prevp) != (DEFBUF *)NULL) {
+      prevp = dp->link;
+      free(dp->repl);                /* Free the replacement */
+      free((char *)dp);              /* Free the symbol      */
+    }
+    global->symtab[i] = NULL;
+  }
+}
+
+
 void outdefines(struct Global *global)
 {
   DEFBUF *dp;
   DEFBUF **syp;
 
-  deldefines(global);                   /* Delete built-in #defines     */
+  delbuiltindefines(global);                   /* Delete built-in #defines     */
   for (syp = global->symtab; syp < &global->symtab[SBSIZE]; syp++) {
     if ((dp = *syp) != (DEFBUF *) NULL) {
       do {

--- a/cppadd.h
+++ b/cppadd.h
@@ -405,7 +405,8 @@ void dumpadef(char *, register DEFBUF *);
 #endif
 ReturnCode openfile(struct Global *,char *);
 int cget(struct Global *);
-void deldefines(struct Global *);
+void delbuiltindefines(struct Global *);
+void delalldefines(struct Global *);
 char *Getmem(struct Global *, int);
 ReturnCode openinclude(struct Global *, char *, int);
 ReturnCode expstuff(struct Global *, char *, char *);


### PR DESCRIPTION
There were a lot of leaks : global context, define replacements...
I fixed those I happened to see in my programs, but there might still be a few left.