### PR TITLE
install: create dirs if they don't exist

### DIFF
--- a/makefile
+++ b/makefile
@@ -87,7 +87,7 @@ tgz:
 	gzip $$name.tar ; chmod a+r $$name.tar.gz ; mv $$name.tar.gz $$name/)
 
 install: $(FILECPP)
-	install "$(FILECPP)" "$(DESTDIR)$(PREFIX)/bin"
+	install -D "$(FILECPP)" -t "$(DESTDIR)$(PREFIX)/bin"
 
 uninstall:
 	rm -f "$(DESTDIR)$(PREFIX)/bin/$(FILECPP)"


### PR DESCRIPTION
I ran into a problem when working on a Dockerfile for curl-www (When installing fcpp, the directories weren't getting created):

```
RUN git clone --depth 1 https://github.com/bagder/fcpp \
    && cd fcpp  \
    && make \
    && make DESTDIR=/tmp/fcpp install

FROM debian:bullseye-slim
COPY --from=0 /tmp/fcpp /
```